### PR TITLE
dadata company prompt type parameter made nullable

### DIFF
--- a/src/DaDataCompany.php
+++ b/src/DaDataCompany.php
@@ -49,7 +49,7 @@ class DaDataCompany extends DaDataService
      * @param string $company
      * @param int $count
      * @param array $status
-     * @param int $type
+     * @param int|null $type
      * @param string|null $locations
      * @param string|null $locations_boost
      * @return array
@@ -58,7 +58,7 @@ class DaDataCompany extends DaDataService
     public function prompt(string $company,
                            int $count = 10,
                            array $status = [CompanyStatus::ACTIVE],
-                           int $type = CompanyType::INDIVIDUAL,
+                           ?int $type = CompanyType::INDIVIDUAL,
                            string $locations = null,
                            string $locations_boost = null
 


### PR DESCRIPTION
Добрый день.

Есть проблема с параметром type функции prompt класса DaDataCompany.

Параметр type - это тип организации: юр. лицо (1) или ИП (0). Тип параметра - int, по умолчанию он принимает значение 1. 

Нет возможности искать все типы компаний, хотя по умолчанию поиск по компаниям Dadata работает именно так - http://prntscr.com/12zq7kf. Логично сделать данный параметр nullable, тогда можно будет передать null и произвести поиск по всем типам компаний.

Забавно, но на данный момент можно сделать костыль: передать в параметр type значение, которого нет в константах класса CompanyType (0 и 1), например, 2. Тогда на 93 строке класса DaDataCompany выполнится следующий код, параметр type установится в null и поиск пройдет по всем типам компаний:
`'type' => CompanyType::$map[$type] ?? null,`
